### PR TITLE
fix: pointer-events: stroke; to path tag

### DIFF
--- a/projects/ng-draw-flow/src/lib/components/connections/connection.component.less
+++ b/projects/ng-draw-flow/src/lib/components/connections/connection.component.less
@@ -10,7 +10,7 @@
         fill: none;
         stroke-width: var(--df-connection-stroke-width);
         stroke: var(--df-connection-color);
-        pointer-events: all;
+        pointer-events: stroke;
         transform: translateZ(0);
 
         &:hover {


### PR DESCRIPTION
To make the lines not overlap each other, I added pointer-events: stroke;
