### PR TITLE
feat: enable configurable arrowheads for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ imports: [
 ```
 
 Then, within the providers section, register the components that you want to be available for use as nodes within the
-graph editor:
+graph editor and optionally configure connection arrowheads:
 
 `app.module.ts`
 
@@ -73,9 +73,15 @@ providers: [
     nodes: {
       yourNode: YourNodeComponent,
     },
+    connection: {
+      arrowhead: {type: DfArrowhead.Arrow},
+    },
   }),
 ];
 ```
+
+The `connection.arrowhead` option accepts a `DfArrowhead` value (`Arrow`, `ArrowClosed`, or `None`) and optional `width`
+and `height` settings.
 
 ## Set Up Data Model and Control for Graph Structure
 

--- a/projects/demo/src/pages/documentation/configuration-and-public-api/configuration-and-public-api.component.html
+++ b/projects/demo/src/pages/documentation/configuration-and-public-api/configuration-and-public-api.component.html
@@ -63,6 +63,29 @@
                         <code>SmoothStep</code>
                         : Determines the corner rounding radius in pixels
                     </li>
+                    <li class="tui-list__item">
+                        <code>arrowhead</code>
+                        <ul>
+                            <li>
+                                <code>type</code>
+                                : arrowhead shape (
+                                <code>DfArrowhead.Arrow</code>
+                                ,
+                                <code>DfArrowhead.ArrowClosed</code>
+                                ,
+                                <code>DfArrowhead.None</code>
+                                )
+                            </li>
+                            <li>
+                                <code>width</code>
+                                : arrowhead width in pixels
+                            </li>
+                            <li>
+                                <code>height</code>
+                                : arrowhead height in pixels
+                            </li>
+                        </ul>
+                    </li>
                 </ul>
             </li>
         </ul>

--- a/projects/demo/src/pages/documentation/configuration-and-public-api/examples/configurations.md
+++ b/projects/demo/src/pages/documentation/configuration-and-public-api/examples/configurations.md
@@ -9,6 +9,7 @@ providers: [
     connection: {
       type: DfConnectionType.Bezier,
       curvature: 1,
+      arrowhead: {type: DfArrowhead.ArrowClosed, width: 12, height: 8},
     },
     options: {
       nodeDragThreshold: 1,

--- a/projects/demo/src/pages/documentation/connections/bezier-example/bezier-example.component.ts
+++ b/projects/demo/src/pages/documentation/connections/bezier-example/bezier-example.component.ts
@@ -3,6 +3,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import type {DfDataModel} from '@ng-draw-flow/core';
 import {
+    DfArrowhead,
     DfConnectionPoint,
     DfConnectionType,
     dfPanZoomOptionsProvider,
@@ -33,7 +34,7 @@ import {InputNodeComponent, OutputNodeComponent} from '../../../../app/modules/n
         provideNgDrawFlowConfigs({
             connection: {
                 type: DfConnectionType.Bezier,
-                arrowhead: 'triangle',
+                arrowhead: {type: DfArrowhead.ArrowClosed},
                 curvature: 0.25,
             },
             nodes: {

--- a/projects/demo/src/pages/documentation/connections/connections.component.html
+++ b/projects/demo/src/pages/documentation/connections/connections.component.html
@@ -13,6 +13,36 @@
     </section>
 
     <section class="tui-space_top-4">
+        <h3>Arrowheads</h3>
+        <p>
+            Customize connection arrowheads using the
+            <code>connection.arrowhead</code>
+            option.
+        </p>
+
+        <ul class="tui-list tui-list_extra-small">
+            <li class="tui-list__item">
+                <code>type</code>
+                : arrowhead style (
+                <code>DfArrowhead.None</code>
+                ,
+                <code>DfArrowhead.Arrow</code>
+                ,
+                <code>DfArrowhead.ArrowClosed</code>
+                )
+            </li>
+            <li class="tui-list__item">
+                <code>width</code>
+                : width in pixels
+            </li>
+            <li class="tui-list__item">
+                <code>height</code>
+                : height in pixels
+            </li>
+        </ul>
+    </section>
+
+    <section class="tui-space_top-4">
         <h3>SmoothStep</h3>
         <p>
             SmoothStep edges use horizontal and vertical segments joined by rounded bends, making them suitable for

--- a/projects/demo/src/pages/documentation/connections/smooth-step-example/smooth-step-example.component.ts
+++ b/projects/demo/src/pages/documentation/connections/smooth-step-example/smooth-step-example.component.ts
@@ -3,6 +3,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import type {DfDataModel} from '@ng-draw-flow/core';
 import {
+    DfArrowhead,
     DfConnectionPoint,
     DfConnectionType,
     dfPanZoomOptionsProvider,
@@ -33,7 +34,7 @@ import {InputNodeComponent, OutputNodeComponent} from '../../../../app/modules/n
         provideNgDrawFlowConfigs({
             connection: {
                 type: DfConnectionType.SmoothStep,
-                arrowhead: 'triangle',
+                arrowhead: {type: DfArrowhead.ArrowClosed},
                 curvature: 10,
             },
             nodes: {

--- a/projects/demo/src/pages/examples/editor/editor.component.ts
+++ b/projects/demo/src/pages/examples/editor/editor.component.ts
@@ -14,6 +14,7 @@ import type {
     DfEvent,
 } from '@ng-draw-flow/core';
 import {
+    DfArrowhead,
     DfConnectionPoint,
     DfConnectionType,
     dfCycleDetectionValidator,
@@ -53,7 +54,7 @@ import {SimpleNodeComponent} from '../../../app/modules/nodes';
         provideNgDrawFlowConfigs({
             connection: {
                 type: DfConnectionType.SmoothStep,
-                arrowhead: 'none',
+                arrowhead: {type: DfArrowhead.Arrow},
                 curvature: 10,
             },
             nodes: {

--- a/projects/ng-draw-flow/README.md
+++ b/projects/ng-draw-flow/README.md
@@ -51,7 +51,7 @@ imports: [
 ```
 
 Then, within the providers section, register the components that you want to be available for use as nodes within the
-graph editor:
+graph editor and optionally configure connection arrowheads:
 
 `app.module.ts`
 
@@ -61,9 +61,15 @@ providers: [
     nodes: {
       yourNode: YourNodeComponent,
     },
+    connection: {
+      arrowhead: {type: DfArrowhead.Arrow},
+    },
   }),
 ];
 ```
+
+The `connection.arrowhead` option accepts a `DfArrowhead` value (`Arrow`, `ArrowClosed`, or `None`) and optional `width`
+and `height` settings.
 
 ## Set Up Data Model and Control for Graph Structure
 

--- a/projects/ng-draw-flow/src/lib/components/connections/connection/connection.component.svg
+++ b/projects/ng-draw-flow/src/lib/components/connections/connection/connection.component.svg
@@ -1,4 +1,42 @@
 <svg class="connection" [class.optimize-speed]="optimization$ | async">
+    <defs>
+        <marker
+            id="df-arrowhead-arrowClosed"
+            [attr.viewBox]="arrowViewBox"
+            refX="0"
+            refY="0"
+            [attr.markerWidth]="arrowMarkerWidth"
+            [attr.markerHeight]="arrowMarkerHeight"
+            orient="auto-start-reverse"
+            markerUnits="strokeWidth"
+        >
+            <polyline
+                [attr.points]="arrowClosedPoints"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="context-stroke"
+                stroke="context-stroke"
+            />
+        </marker>
+        <marker
+            id="df-arrowhead-arrow"
+            [attr.viewBox]="arrowViewBox"
+            refX="0"
+            refY="0"
+            [attr.markerWidth]="arrowMarkerWidth"
+            [attr.markerHeight]="arrowMarkerHeight"
+            orient="auto-start-reverse"
+            markerUnits="strokeWidth"
+        >
+            <polyline
+                [attr.points]="arrowPoints"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                fill="none"
+                stroke="context-stroke"
+            />
+        </marker>
+    </defs>
     <path class="selectable-area" [attr.d]="path$ | async" (dfSelectableElement)="onSelectedChanged($event)" />
-    <path class="main-path" [attr.d]="path$ | async" [class.df-selected]="selected" />
+    <path class="main-path" [attr.d]="path$ | async" [class.df-selected]="selected" [attr.marker-end]="markerEnd" />
 </svg>

--- a/projects/ng-draw-flow/src/lib/components/connections/connection/connection.component.ts
+++ b/projects/ng-draw-flow/src/lib/components/connections/connection/connection.component.ts
@@ -28,6 +28,7 @@ import {SelectableElementDirective} from '../../../directives';
 import {createConnectorHash, deepEqual} from '../../../helpers';
 import {DRAW_FLOW_OPTIONS} from '../../../ng-draw-flow.configs';
 import type {
+    DfArrowheadOptions,
     DfConnectorData,
     DfDataConnection,
     DfDataConnector,
@@ -54,6 +55,22 @@ export class ConnectionComponent {
     private readonly coordinatesService = inject(CoordinatesService);
     private readonly options = inject(DRAW_FLOW_OPTIONS);
     protected selected = false;
+    private readonly arrowhead: DfArrowheadOptions = this.options.connection.arrowhead;
+
+    protected readonly markerEnd =
+        this.arrowhead.type === 'none'
+            ? null
+            : `url(#df-arrowhead-${this.arrowhead.type})`;
+
+    private readonly arrowWidth = this.arrowhead.width;
+    private readonly arrowHeight = this.arrowhead.height;
+
+    protected readonly arrowMarkerWidth = this.arrowWidth + this.arrowHeight;
+    protected readonly arrowMarkerHeight = this.arrowHeight * 2;
+
+    protected readonly arrowViewBox = `-${this.arrowMarkerWidth} -${this.arrowMarkerHeight / 2} ${this.arrowMarkerWidth} ${this.arrowMarkerHeight}`;
+    protected readonly arrowPoints = `-${this.arrowWidth},-${this.arrowHeight / 2} 0,0 -${this.arrowWidth},${this.arrowHeight / 2}`;
+    protected readonly arrowClosedPoints = `${this.arrowPoints} -${this.arrowWidth},-${this.arrowHeight / 2}`;
 
     @Input()
     public connection!: DfDataConnection;

--- a/projects/ng-draw-flow/src/lib/components/scene/scene.component.ts
+++ b/projects/ng-draw-flow/src/lib/components/scene/scene.component.ts
@@ -140,10 +140,6 @@ export class SceneComponent implements ControlValueAccessor, OnInit {
         return `${connection.source.nodeId}-${connection.source.connectorId}to${connection.target.nodeId}-${connection.target.connectorId}`;
     }
 
-    protected originalOrder(): number {
-        return 0;
-    }
-
     public writeValue(value: DfDataModel): void {
         if (!value) {
             return;

--- a/projects/ng-draw-flow/src/lib/ng-draw-flow.configs.ts
+++ b/projects/ng-draw-flow/src/lib/ng-draw-flow.configs.ts
@@ -1,18 +1,22 @@
 import type {FactoryProvider} from '@angular/core';
 import {InjectionToken} from '@angular/core';
 
-import type {DfOptions} from './ng-draw-flow.interfaces';
-import {DfConnectionType} from './ng-draw-flow.interfaces';
+import type {DfOptions, DfOptionsInput} from './ng-draw-flow.interfaces';
+import {DfArrowhead, DfConnectionType} from './ng-draw-flow.interfaces';
 
 export const DRAW_FLOW_DEFAULT_OPTIONS: DfOptions = {
     connection: {
-        arrowhead: 'none',
+        arrowhead: {type: DfArrowhead.None, width: 8, height: 4},
         type: DfConnectionType.Bezier,
         curvature: 0.25,
     },
     nodes: {},
     options: {
         nodeDragThreshold: 1,
+        nodesDraggable: true,
+        nodesDeletable: true,
+        connectionsDeletable: true,
+        connectionsCreatable: true,
     },
 };
 
@@ -20,12 +24,26 @@ export const DRAW_FLOW_OPTIONS = new InjectionToken('[DRAW_FLOW_OPTIONS]: Option
     factory: () => DRAW_FLOW_DEFAULT_OPTIONS,
 });
 
-export function provideNgDrawFlowConfigs(options: Partial<DfOptions>): FactoryProvider {
+export function provideNgDrawFlowConfigs(options: DfOptionsInput = {}): FactoryProvider {
     return {
         provide: DRAW_FLOW_OPTIONS,
         useFactory: (): DfOptions => ({
-            ...DRAW_FLOW_DEFAULT_OPTIONS,
-            ...options,
+            connection: {
+                ...DRAW_FLOW_DEFAULT_OPTIONS.connection,
+                ...options.connection,
+                arrowhead: {
+                    ...DRAW_FLOW_DEFAULT_OPTIONS.connection.arrowhead,
+                    ...options.connection?.arrowhead,
+                },
+            },
+            nodes: {
+                ...DRAW_FLOW_DEFAULT_OPTIONS.nodes,
+                ...options.nodes,
+            },
+            options: {
+                ...DRAW_FLOW_DEFAULT_OPTIONS.options,
+                ...options.options,
+            },
         }),
     };
 }

--- a/projects/ng-draw-flow/src/lib/ng-draw-flow.interfaces.ts
+++ b/projects/ng-draw-flow/src/lib/ng-draw-flow.interfaces.ts
@@ -5,7 +5,6 @@ import type {DrawFlowBaseNode} from './ng-draw-flow-node.base';
 export enum DfConnectionType {
     Bezier = 'bezier',
     SmoothStep = 'smoothStep',
-    Step = 'step',
 }
 
 export enum DfConnectorPosition {
@@ -15,18 +14,54 @@ export enum DfConnectorPosition {
     Left = 'left',
 }
 
+export enum DfArrowhead {
+    Arrow = 'arrow',
+    ArrowClosed = 'arrowClosed',
+    None = 'none',
+}
+
+export interface DfArrowheadOptions {
+    type: DfArrowhead;
+    width: number;
+    height: number;
+}
+
+export interface DfArrowheadOptionsInput {
+    type?: DfArrowhead;
+    width?: number;
+    height?: number;
+}
+
 export interface DfConnectionOptions {
     type: DfConnectionType;
-    arrowhead: 'none' | 'triangle';
+    arrowhead: DfArrowheadOptions;
     curvature: number;
+}
+
+export interface DfConnectionOptionsInput {
+    type: DfConnectionType;
+    arrowhead: DfArrowheadOptionsInput;
+    curvature: number;
+}
+
+export interface DfWorkspaceOptions {
+    nodeDragThreshold: number;
+    nodesDraggable: boolean;
+    nodesDeletable: boolean;
+    connectionsDeletable: boolean;
+    connectionsCreatable: boolean;
 }
 
 export interface DfOptions {
     connection: DfConnectionOptions;
     nodes: DfComponents;
-    options: {
-        nodeDragThreshold: number;
-    };
+    options: DfWorkspaceOptions;
+}
+
+export interface DfOptionsInput {
+    connection?: Partial<DfConnectionOptionsInput>;
+    nodes?: DfComponents;
+    options?: Partial<DfWorkspaceOptions>;
 }
 
 export type DfComponents = Record<string, Type<DrawFlowBaseNode>>;


### PR DESCRIPTION
introduce arrowhead options to choose marker shape and dimensions

render SVG markers from these options, letting width and height vary independently

Fixes # <!-- link to a relevant issue. -->
