### PR TITLE
feat(ng-draw-flow): add remove node public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ If a custom node previously overrode the `invalid` input/setter, move that logic
 `protected override get invalidState()` and combine it with `this.invalidSignal()`.
 
 `NgDrawFlowStoreService` now has signal snapshots such as `dataModel`, `selectedNode`, `selectedConnection`,
-`lastNodeMoved` and `lastConnectionCreated`; the existing `$` streams remain available for RxJS-based integrations.
+`lastNodeMoved` and `lastConnectionCreated`; the existing `$` streams remain available for RxJS-based integrations. It
+also mirrors runtime controls such as `setPosition`, `removeConnection` and `removeNode`, where `removeNode` accepts a
+node object or node id and deletes related connections.
 
 ## Installation
 

--- a/projects/demo/src/pages/documentation/configuration-and-public-api/configuration-and-public-api.component.html
+++ b/projects/demo/src/pages/documentation/configuration-and-public-api/configuration-and-public-api.component.html
@@ -219,6 +219,11 @@
                 existing connection in the graph.
             </li>
             <li class="tui-list__item">
+                <code>removeNode(node: DfDataNode | string): void</code>
+                : Programmatically removes a node by object or id and removes every connection that uses this node as a
+                source or target.
+            </li>
+            <li class="tui-list__item">
                 <code>NgDrawFlowStoreService</code>
                 : Root-scoped facade for runtime state and controls—inject it anywhere to mirror component actions (
                 <code>zoomIn</code>
@@ -232,6 +237,8 @@
                 <code>setScale</code>
                 ,
                 <code>removeConnection</code>
+                ,
+                <code>removeNode</code>
                 ) and observe live data (
                 <code>dataModel</code>
                 ,

--- a/projects/demo/src/pages/examples/editor/editor.component.html
+++ b/projects/demo/src/pages/examples/editor/editor.component.html
@@ -44,6 +44,16 @@
                     {{ fullscreen() ? 'Exit from fullscreen' : 'Fullscreen' }}
                 </button>
 
+                <button
+                    size="s"
+                    tuiButton
+                    type="button"
+                    class="remove-node-btn"
+                    (click)="drawFlowStore.removeNode('node-3')"
+                >
+                    Remove node-3
+                </button>
+
                 <div class="scale-controls">
                     <button
                         size="s"

--- a/projects/demo/src/pages/examples/editor/editor.component.less
+++ b/projects/demo/src/pages/examples/editor/editor.component.less
@@ -22,6 +22,10 @@
             inset-block-start: 7.8rem;
         }
 
+        .remove-node-btn {
+            inset-block-start: 10.6rem;
+        }
+
         .selection-info {
             inset-block-start: 5rem;
         }
@@ -38,6 +42,12 @@
     position: absolute;
     inset-inline-end: 1.25rem;
     inset-block-start: 3.75rem;
+}
+
+.remove-node-btn {
+    position: absolute;
+    inset-inline-end: 1.25rem;
+    inset-block-start: 6.25rem;
 }
 
 .scale-controls {

--- a/projects/demo/src/pages/examples/editor/examples/editor.template.md
+++ b/projects/demo/src/pages/examples/editor/examples/editor.template.md
@@ -34,6 +34,16 @@
     {{ (fullscreen$ | async) ? 'Exit from fullscreen' : 'Fullscreen' }}
   </button>
 
+  <button
+    class="remove-node-btn"
+    size="s"
+    tuiButton
+    type="button"
+    (click)="drawFlowStore.removeNode('node-3')"
+  >
+    Remove node-3
+  </button>
+
   <div class="scale-controls">
     <button
       size="s"

--- a/projects/ng-draw-flow/README.md
+++ b/projects/ng-draw-flow/README.md
@@ -55,7 +55,9 @@ If a custom node previously overrode the `invalid` input/setter, move that logic
 `protected override get invalidState()` and combine it with `this.invalidSignal()`.
 
 `NgDrawFlowStoreService` now has signal snapshots such as `dataModel`, `selectedNode`, `selectedConnection`,
-`lastNodeMoved` and `lastConnectionCreated`; the existing `$` streams remain available for RxJS-based integrations.
+`lastNodeMoved` and `lastConnectionCreated`; the existing `$` streams remain available for RxJS-based integrations. It
+also mirrors runtime controls such as `setPosition`, `removeConnection` and `removeNode`, where `removeNode` accepts a
+node object or node id and deletes related connections.
 
 ## Installation
 

--- a/projects/ng-draw-flow/src/lib/ng-draw-flow.component.spec.ts
+++ b/projects/ng-draw-flow/src/lib/ng-draw-flow.component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './components/pan-zoom/pan-zoom.options';
 import {PanZoomService} from './components/pan-zoom/pan-zoom.service';
 import {NgDrawFlowComponent} from './ng-draw-flow.component';
+import {DfConnectionPoint} from './ng-draw-flow.interfaces';
 import {NgDrawFlowStoreService} from './services/ng-draw-flow-store.service';
 import {SelectionService} from './services/selection.service';
 
@@ -57,7 +58,10 @@ describe('NgDrawFlowComponent', () => {
                     },
                     {
                         provide: ConnectionsService,
-                        useValue: {removeConnection: jest.fn()},
+                        useValue: {
+                            removeConnection: jest.fn(),
+                            setConnections: jest.fn(),
+                        },
                     },
                     {
                         provide: NgDrawFlowStoreService,
@@ -68,6 +72,8 @@ describe('NgDrawFlowComponent', () => {
                             clearSelectedNode: jest.fn(),
                             clearSelectedConnection: jest.fn(),
                             setScaleValue: jest.fn(),
+                            emitNodeDeleted: jest.fn(),
+                            emitConnectionDeleted: jest.fn(),
                         },
                     },
                     {
@@ -158,5 +164,79 @@ describe('NgDrawFlowComponent', () => {
         });
 
         expect(scheduleViewportFraming).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes a node with related connections through public API', () => {
+        const fixture = TestBed.createComponent(NgDrawFlowComponent);
+        const component = fixture.componentInstance;
+        const store = fixture.debugElement.injector.get(NgDrawFlowStoreService);
+        const connectionsService = fixture.debugElement.injector.get(ConnectionsService);
+        const nodeDeletedSpy = jest.spyOn(component['nodeDeleted'], 'emit');
+        const connectionDeletedSpy = jest.spyOn(component['connectionDeleted'], 'emit');
+        const model = {
+            nodes: [
+                {
+                    id: 'node-1',
+                    data: {type: 'simpleNode'},
+                    position: {x: 0, y: 0},
+                },
+                {
+                    id: 'node-2',
+                    data: {type: 'simpleNode'},
+                    position: {x: 10, y: 10},
+                },
+            ],
+            connections: [
+                {
+                    source: {
+                        nodeId: 'node-1',
+                        connectorId: 'source',
+                        connectorType: DfConnectionPoint.Output,
+                    },
+                    target: {
+                        nodeId: 'node-2',
+                        connectorId: 'target',
+                        connectorType: DfConnectionPoint.Input,
+                    },
+                },
+            ],
+        };
+
+        component.writeValue(model);
+        component.removeNode('node-1');
+
+        expect(component['form'].value).toEqual({
+            nodes: [model.nodes[1]],
+            connections: [],
+        });
+        expect(connectionsService.setConnections).toHaveBeenCalledWith([]);
+        expect(store.emitNodeDeleted).toHaveBeenCalledWith({
+            target: model.nodes[0],
+            model: {
+                nodes: [model.nodes[1]],
+                connections: [],
+            },
+        });
+        expect(store.emitConnectionDeleted).toHaveBeenCalledWith({
+            target: model.connections[0],
+            model: {
+                nodes: [model.nodes[1]],
+                connections: [],
+            },
+        });
+        expect(nodeDeletedSpy).toHaveBeenCalledWith({
+            target: model.nodes[0],
+            model: {
+                nodes: [model.nodes[1]],
+                connections: [],
+            },
+        });
+        expect(connectionDeletedSpy).toHaveBeenCalledWith({
+            target: model.connections[0],
+            model: {
+                nodes: [model.nodes[1]],
+                connections: [],
+            },
+        });
     });
 });

--- a/projects/ng-draw-flow/src/lib/ng-draw-flow.component.ts
+++ b/projects/ng-draw-flow/src/lib/ng-draw-flow.component.ts
@@ -61,7 +61,7 @@ import {SelectionService} from './services/selection.service';
  *   …) and re-emits high-level events so host applications can stay
  *   framework-agnostic.
  * * Exposes a minimal public API (`zoomIn`, `zoomOut`, `resetPosition`,
- *   `setScale`, `removeConnection`) for programmatic control.
+ *   `setScale`, `removeConnection`, `removeNode`) for programmatic control.
  * * Broadcasts state and events through `NgDrawFlowStoreService` so host apps
  *   can react without a direct reference to the component instance.
  */
@@ -130,7 +130,7 @@ export class NgDrawFlowComponent
     /** Fired after a new edge is successfully created. */
     protected readonly connectionCreated = output<DfEvent<DfDataConnection>>();
 
-    /** Fired after an edge is removed—via UI or `removeConnection()`. */
+    /** Fired after an edge is removed—via UI, `removeConnection()` or `removeNode()`. */
     protected readonly connectionDeleted = output<DfEvent<DfDataConnection>>();
 
     /** Fired when an edge receives focus in the scene. */
@@ -248,6 +248,48 @@ export class NgDrawFlowComponent
     /** Method that removes an existing edge. */
     public removeConnection(connection: DfDataConnection): void {
         this.connectionsService.removeConnection(connection);
+    }
+
+    /** Method that removes an existing node and all related edges. */
+    public removeNode(node: DfDataNode | string): void {
+        const nodeId = typeof node === 'string' ? node : node.id;
+        const current = this.form.value;
+        const deleted = current.nodes.find(({id}) => id === nodeId);
+
+        if (!deleted) {
+            return;
+        }
+
+        const deletedConnections = current.connections.filter(
+            (connection) =>
+                connection.source.nodeId === nodeId ||
+                connection.target.nodeId === nodeId,
+        );
+        const model: DfDataModel = {
+            ...current,
+            nodes: current.nodes.filter(({id}) => id !== nodeId),
+            connections: current.connections.filter(
+                (connection) =>
+                    connection.source.nodeId !== nodeId &&
+                    connection.target.nodeId !== nodeId,
+            ),
+        };
+        const event: DfEvent<DfDataNode> = {target: deleted as DfDataNode, model};
+
+        this.form.setValue(model);
+        this.connectionsService.setConnections(model.connections);
+        this.store.emitNodeDeleted(event);
+        this.nodeDeleted.emit(event);
+
+        deletedConnections.forEach((connection) => {
+            const connectionEvent: DfEvent<DfDataConnection> = {
+                target: connection,
+                model,
+            };
+
+            this.store.emitConnectionDeleted(connectionEvent);
+            this.connectionDeleted.emit(connectionEvent);
+        });
     }
 
     /** Clears any active selection in the scene. */

--- a/projects/ng-draw-flow/src/lib/services/ng-draw-flow-store.service.spec.ts
+++ b/projects/ng-draw-flow/src/lib/services/ng-draw-flow-store.service.spec.ts
@@ -53,6 +53,7 @@ describe('NgDrawFlowStoreService', () => {
             resetPosition: jest.fn(),
             setScale: jest.fn(),
             removeConnection: jest.fn(),
+            removeNode: jest.fn(),
             clearSelection: jest.fn(),
         } as unknown as NgDrawFlowComponent;
 
@@ -63,12 +64,14 @@ describe('NgDrawFlowStoreService', () => {
         service.resetPosition();
         service.setScale(1.25);
         service.removeConnection(connection);
+        service.removeNode(node);
 
         expect(host.zoomIn).toHaveBeenCalled();
         expect(host.zoomOut).toHaveBeenCalled();
         expect(host.resetPosition).toHaveBeenCalled();
         expect(host.setScale).toHaveBeenCalledWith(1.25);
         expect(host.removeConnection).toHaveBeenCalledWith(connection);
+        expect(host.removeNode).toHaveBeenCalledWith(node);
         expect(service.scale()).toBe(125);
 
         service.detach(host);

--- a/projects/ng-draw-flow/src/lib/services/ng-draw-flow-store.service.ts
+++ b/projects/ng-draw-flow/src/lib/services/ng-draw-flow-store.service.ts
@@ -170,6 +170,13 @@ export class NgDrawFlowStoreService {
     }
 
     /**
+     * Removes the provided node via the live editor instance.
+     */
+    public removeNode(node: DfDataNode | string): void {
+        this.host?.removeNode(node);
+    }
+
+    /**
      * Replaces the cached data model and revalidates current selections.
      */
     public updateDataModel(model: DfDataModel): void {


### PR DESCRIPTION
Add public removeNode API to NgDrawFlowComponent and NgDrawFlowStoreService.

The new API removes a node by object or id, deletes related connections, and emits the same nodeDeleted/connectionDeleted events used by existing graph updates.
Fixes #328
