### PR TITLE
fix(ng-draw-flow): centralize node state classes on wrapper

### DIFF
--- a/projects/demo/src/pages/documentation/validation/validation.component.html
+++ b/projects/demo/src/pages/documentation/validation/validation.component.html
@@ -27,9 +27,9 @@
             <code>invalidState</code>
             getter to combine local UI validity with
             <code>invalidSignal()</code>
-            supplied by graph validators. Core uses the result to apply
+            supplied by graph validators. Core reads the result from the custom component and applies
             <code>.df-invalid</code>
-            to the custom node host.
+            to the editor node wrapper.
         </p>
         @if (validationExamples.LocalValidation; as localValidation) {
             <tui-doc-code

--- a/projects/ng-draw-flow/src/lib/components/node/mocks/host.component.mock.ts
+++ b/projects/ng-draw-flow/src/lib/components/node/mocks/host.component.mock.ts
@@ -8,7 +8,7 @@ import {NodeComponent} from '../node.component';
     imports: [NodeComponent],
     template: `
         <df-node
-            [invalid]="invalid"
+            [invalid]="invalid()"
             [node]="node()"
         />
     `,
@@ -16,7 +16,7 @@ import {NodeComponent} from '../node.component';
 })
 export class HostComponent {
     public readonly nodeComponent = viewChild.required(NodeComponent);
-    public invalid = false;
+    public readonly invalid = signal(false);
     public readonly node = signal<DfDataInitialNode | DfDataNode>({
         id: 'draft-node',
         data: {type: 'simpleNode'},

--- a/projects/ng-draw-flow/src/lib/components/node/mocks/node-content.component.mock.ts
+++ b/projects/ng-draw-flow/src/lib/components/node/mocks/node-content.component.mock.ts
@@ -1,11 +1,22 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
 
 import {DrawFlowBaseNode} from '../../../ng-draw-flow-node.base';
 
 @Component({
     standalone: true,
     selector: 'mock-node-content',
-    template: '<div class="mock-node">Mock</div>',
+    imports: [ReactiveFormsModule],
+    template: '<input class="mock-node" [formControl]="control" />',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MockNodeContentComponent extends DrawFlowBaseNode {}
+export class MockNodeContentComponent extends DrawFlowBaseNode {
+    public readonly control = new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+    });
+
+    protected override get invalidState(): boolean {
+        return this.invalidSignal() || (this.control.touched && this.control.invalid);
+    }
+}

--- a/projects/ng-draw-flow/src/lib/components/node/node-content.renderer.ts
+++ b/projects/ng-draw-flow/src/lib/components/node/node-content.renderer.ts
@@ -23,6 +23,7 @@ export interface DfNodeContentInputs {
 
 export interface DfNodeContentRenderer {
     readonly nativeElement: HTMLElement;
+    readonly invalid: boolean;
     readonly inputConnectors: Signal<readonly DfInputComponent[]>;
     readonly outputConnectors: Signal<readonly DfOutputComponent[]>;
     readonly connectorUpdates$: Observable<void>;
@@ -42,6 +43,10 @@ class ComponentNodeContentRenderer implements DfNodeContentRenderer {
 
     public get nativeElement(): HTMLElement {
         return this.componentRef.location.nativeElement;
+    }
+
+    public get invalid(): boolean {
+        return this.componentRef.instance.invalid;
     }
 
     public syncInputs(inputs: DfNodeContentInputs): void {

--- a/projects/ng-draw-flow/src/lib/components/node/node.component.spec.ts
+++ b/projects/ng-draw-flow/src/lib/components/node/node.component.spec.ts
@@ -289,6 +289,118 @@ describe('NodeComponent', () => {
         expect(innerComponent.selected).toBe(true);
     });
 
+    it('applies selected and graph-invalid classes only to the node wrapper', async () => {
+        const fixture = MockRender(HostComponent);
+        const host = fixture.point.componentInstance;
+        const component = host.nodeComponent();
+        const innerComponent = ngMocks.findInstance(MockNodeContentComponent);
+        const nodeElement = fixture.nativeElement.querySelector(
+            '.draw-flow-node',
+        ) as HTMLElement;
+        const contentElement = fixture.nativeElement.querySelector(
+            'mock-node-content',
+        ) as HTMLElement;
+
+        (component as any).onSelectedChanged(true);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-selected')).toBe(true);
+        expect(nodeElement.classList.contains('df-invalid')).toBe(false);
+        expect(contentElement.classList.contains('df-selected')).toBe(false);
+        expect(contentElement.classList.contains('df-invalid')).toBe(false);
+        expect(innerComponent.selected).toBe(true);
+        expect(innerComponent.invalid).toBe(false);
+
+        host.invalid.set(true);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-selected')).toBe(true);
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+        expect(contentElement.classList.contains('df-selected')).toBe(false);
+        expect(contentElement.classList.contains('df-invalid')).toBe(false);
+        expect(innerComponent.selected).toBe(true);
+        expect(innerComponent.invalid).toBe(true);
+
+        (component as any).onSelectedChanged(false);
+        host.invalid.set(false);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-selected')).toBe(false);
+        expect(nodeElement.classList.contains('df-invalid')).toBe(false);
+        expect(contentElement.classList.contains('df-selected')).toBe(false);
+        expect(contentElement.classList.contains('df-invalid')).toBe(false);
+        expect(innerComponent.selected).toBe(false);
+        expect(innerComponent.invalid).toBe(false);
+    });
+
+    it('combines graph and local custom-node errors on the invalid wrapper class', async () => {
+        const fixture = MockRender(HostComponent);
+        const host = fixture.point.componentInstance;
+        const innerComponent = ngMocks.findInstance(MockNodeContentComponent);
+        const nodeElement = fixture.nativeElement.querySelector(
+            '.draw-flow-node',
+        ) as HTMLElement;
+        const formInput = fixture.nativeElement.querySelector(
+            'mock-node-content input',
+        ) as HTMLInputElement;
+        const contentElement = fixture.nativeElement.querySelector(
+            'mock-node-content',
+        ) as HTMLElement;
+
+        expect(innerComponent.control.touched).toBe(false);
+        expect(innerComponent.control.invalid).toBe(true);
+        expect(nodeElement.classList.contains('df-invalid')).toBe(false);
+        expect(contentElement.classList.contains('df-invalid')).toBe(false);
+
+        formInput.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+        expect(innerComponent.control.touched).toBe(true);
+        expect(innerComponent.control.invalid).toBe(true);
+        expect(contentElement.classList.contains('df-invalid')).toBe(false);
+
+        host.invalid.set(true);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+
+        formInput.value = 'valid';
+        formInput.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+        expect(innerComponent.control.invalid).toBe(false);
+
+        formInput.value = '';
+        formInput.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+        expect(innerComponent.control.invalid).toBe(true);
+
+        host.invalid.set(false);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(true);
+
+        formInput.value = 'valid';
+        formInput.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(nodeElement.classList.contains('df-invalid')).toBe(false);
+        expect(innerComponent.control.invalid).toBe(false);
+    });
+
     it('synchronizes dynamic content when node input is replaced', async () => {
         const fixture = MockRender(HostComponent);
         const host = fixture.point.componentInstance;

--- a/projects/ng-draw-flow/src/lib/components/node/node.component.ts
+++ b/projects/ng-draw-flow/src/lib/components/node/node.component.ts
@@ -187,10 +187,14 @@ export class NodeComponent implements AfterViewInit, OnDestroy {
         return this.nodeInteraction.selected();
     }
 
+    protected isInvalid(): boolean {
+        return this.invalid() || this.nodeContentHost.renderer()?.invalid === true;
+    }
+
     protected nodeClassName(): string {
         const classNames = ['draw-flow-node'];
 
-        if (this.invalid()) {
+        if (this.isInvalid()) {
             classNames.push('df-invalid');
         }
 

--- a/projects/ng-draw-flow/src/lib/ng-draw-flow-node.base.ts
+++ b/projects/ng-draw-flow/src/lib/ng-draw-flow-node.base.ts
@@ -13,13 +13,7 @@ import {DfInputComponent, DfOutputComponent} from './components/connectors';
  * Base abstract class for DrawFlow nodes.
  * Provides common functionality and structure for all node types in the flow diagram.
  */
-@Directive({
-    standalone: true,
-    host: {
-        '[class.df-invalid]': 'this.invalidState',
-        '[class.df-selected]': 'this.selected',
-    },
-})
+@Directive({standalone: true})
 export abstract class DrawFlowBaseNode {
     private readonly cdr = inject(ChangeDetectorRef);
     /**
@@ -68,16 +62,15 @@ export abstract class DrawFlowBaseNode {
     /**
      * Selection state of the node.
      * Changes when the node is clicked or deselected.
-     * Applied as 'df-selected' CSS class when true.
+     * The editor applies the visual state to the node wrapper.
      * @default false
      */
     public readonly selectedSignal = input(false, {alias: 'selected'});
 
     /**
      * Validation state of the node.
-     * Can be manually set to highlight the node with red color,
-     * for example when a form inside the node is invalid.
-     * Applied as 'df-invalid' CSS class when true.
+     * Supplied by graph validators. Override `invalidState` to combine
+     * this input with local validation before the editor styles the wrapper.
      * @default false
      */
     public readonly invalidSignal = input(false, {alias: 'invalid'});
@@ -110,6 +103,11 @@ export abstract class DrawFlowBaseNode {
         this.cdr.markForCheck();
     }
 
+    /**
+     * Effective validation state read by the editor wrapper.
+     * Override to combine graph validation with local component state,
+     * for example when a form inside the node is invalid.
+     */
     protected get invalidState(): boolean {
         return this.invalidSignal();
     }


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
